### PR TITLE
pyInterface: correct logic for file binning

### DIFF
--- a/pyInterface/package/_fileManager.py
+++ b/pyInterface/package/_fileManager.py
@@ -105,11 +105,16 @@ class fileManager(object):
 				for inputFile in inputFiles:
 					pyRootPwa.utils.printInfo("adding bin '" + str(inputFile.binningMap) + "'.")
 					try:
-						self.binList.append(pyRootPwa.utils.multiBin(inputFile.binningMap))
+						latestBin = pyRootPwa.utils.multiBin(inputFile.binningMap)
 					except (TypeError, ValueError):
 						pyRootPwa.utils.printErr("no binning given in config file and no binning map" +
 						                         " found in data file '" + str(inputFile.dataFileName) + "'.")
 						return False
+					for multiBin in self.binList:
+						if latestBin.overlap(multiBin, False):
+							pyRootPwa.utils.printWarn("overlap found of bin '" + str(latestBin) + "' and bin '" + str(multiBin) + "'.")
+					if latestBin not in self.binList:
+						self.binList.append(latestBin)
 		else:
 			for _, inputFiles in self.dataFiles.iteritems():
 				for inputFile in inputFiles:

--- a/pyInterface/package/_fileManager.py
+++ b/pyInterface/package/_fileManager.py
@@ -103,17 +103,22 @@ class fileManager(object):
 		if not self.binList:
 			for _, inputFiles in self.dataFiles.iteritems():
 				for inputFile in inputFiles:
-					pyRootPwa.utils.printInfo("adding bin '" + str(inputFile.binningMap) + "'.")
+					pyRootPwa.utils.printInfo("checking bin '" + str(inputFile.binningMap) + "'.")
 					try:
 						latestBin = pyRootPwa.utils.multiBin(inputFile.binningMap)
 					except (TypeError, ValueError):
 						pyRootPwa.utils.printErr("no binning given in config file and no binning map" +
 						                         " found in data file '" + str(inputFile.dataFileName) + "'.")
 						return False
+					alreadyPresent = False
 					for multiBin in self.binList:
-						if latestBin.overlap(multiBin, False):
+						if latestBin == multiBin:
+							alreadyPresent = True
+							continue
+						elif latestBin.overlap(multiBin, False):
 							pyRootPwa.utils.printWarn("overlap found of bin '" + str(latestBin) + "' and bin '" + str(multiBin) + "'.")
-					if latestBin not in self.binList:
+					if not alreadyPresent:
+						pyRootPwa.utils.printInfo("adding bin '" + str(inputFile.binningMap) + "'.")
 						self.binList.append(latestBin)
 		else:
 			for _, inputFiles in self.dataFiles.iteritems():

--- a/pyInterface/package/utils/_binning.py
+++ b/pyInterface/package/utils/_binning.py
@@ -71,14 +71,22 @@ class multiBin(object):
 		return retval
 
 
-	def overlap(self, other):
+	def overlap(self, other, strict=True):
+		def comparator(left, right, direction):
+			if direction == ">":
+				right, left = left, right
+			if strict:
+				return left <= right
+			else:
+				return left < right
+
 		keys = sorted(self.boundaries.keys())
 		if keys != sorted(other.boundaries.keys()):
 			return False
 		for key in keys:
-			if self.boundaries[key][1] <= other.boundaries[key][0]:
+			if comparator(self.boundaries[key][1], other.boundaries[key][0], "<"):
 				return False
-			if self.boundaries[key][0] >= other.boundaries[key][1]:
+			if comparator(self.boundaries[key][0], other.boundaries[key][1], ">"):
 				return False
 		return True
 

--- a/pyInterface/package/utils/_binning.py
+++ b/pyInterface/package/utils/_binning.py
@@ -76,9 +76,9 @@ class multiBin(object):
 			if direction == ">":
 				right, left = left, right
 			if strict:
-				return left <= right
-			else:
 				return left < right
+			else:
+				return left <= right
 
 		keys = sorted(self.boundaries.keys())
 		if keys != sorted(other.boundaries.keys()):


### PR DESCRIPTION
Check whether a bin is already known in the filemanager before checking
for overlaps, otherwise each bin would print a warning that it overlaps
with itself.

Note that this also changes the overlap function w.r.t. to earlier behaviour.
